### PR TITLE
Update picojson_serializer.h to avoid GCC uninitialized warnings.

### DIFF
--- a/picojson_serializer.h
+++ b/picojson_serializer.h
@@ -192,7 +192,7 @@ namespace picojson {
 
 			template<typename T>
 			T from_value(picojson::value const& v) {
-				T t;
+				T t{}; //Fixes unititialized data warnings from GCC
 				value_converter<T>::from_value(v, t);
 				return t;
 			}


### PR DESCRIPTION
This change was required to fix GCC uninitialized variable warnings. I have a class with uint32_t members which generated "Maybe unitialized" warnings with GCC-4.7.3. The uint32_t class member is initialized to 0 using an initializer list yet the warning persisted. 

Eventually I came across this StackOverflow post that basically hinted towards optimization -O2 as being the root cause. It's the answer by juanchopanza, not the accepted answer. http://stackoverflow.com/questions/20909610/default-initialization-of-aggregates

I quote.

"In order to guarantee zero-initialization of POD aggregate data members, you need to value-initialize your instance. For example,

st s = st(); // C++03 and C++11
st s = {};   // C++03 and C++11
st s{};      // C++11
"

After adding {} after t, my warnings disappeared and all seems well. No other impact on other classes being serialized. Figured I'd submit this patch to assist others who code "warning-free" :)
